### PR TITLE
Initialize esp_timer_create_args_t struct in createTimer()

### DIFF
--- a/src/nesper/timers.nim
+++ b/src/nesper/timers.nim
@@ -22,7 +22,12 @@ proc createTimer*(
       ): esp_timer_handle_t =
   ## !< Timer name, used in esp_timer_dump function
 
-  var create_args: esp_timer_create_args_t
+  var create_args = esp_timer_create_args_t(
+    callback: callback,
+    arg: arg,
+    dispatch_method: dispatch_method,
+    name: name)
+
   var out_handle: esp_timer_handle_t
 
   let ret = esp_timer_create(addr(create_args), addr(out_handle))


### PR DESCRIPTION
Looks like `create_args` was never initialized in `createTimer()`, leading to an assertion failure at runtime.