### PR TITLE
Add barebones CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Start docker
+      run: docker run -itd -e IDF_TARGET=esp32 -v "${GITHUB_WORKSPACE}:/nesper" --name container espressif/idf:v4.4
+    - name: Install nim
+      run: docker exec container bash -c "curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y"
+    - name: Install nesper
+      run: docker exec container bash -c 'cd /nesper && PATH=/root/.nimble/bin:$PATH nimble install -y'
+    - name: I2S example
+      run: docker exec -w /nesper/esp-idf-examples/i2s container bash -c '. /opt/esp/idf/export.sh && PATH=/root/.nimble/bin:$PATH nimble esp_build'


### PR DESCRIPTION
As a first step, I've set up to test one example with ESP IDF v4.4, stable nim and ESP32 as the target.
Just to see whether it works, and if that is the direction to go for #6.
Let me know what you think, and what combinations of IDF, nim, targets and examples should be tested.

You should be able to see how it looks [here](https://github.com/Psirus/nesper/actions/runs/4347397300/jobs/7594659522).

Edit: I just noticed that there is a Dockerfile in the repo, maybe I could just use that, with fewer headaches about $PATH, and maybe even automatic publishing of a Nesper container to Dockerhub in the future. Will look into that later.