### PR TITLE
Fix wifi_example_main to work with latest version

### DIFF
--- a/esp-idf-examples/simplewifi/main/wifi_example_main.nim
+++ b/esp-idf-examples/simplewifi/main/wifi_example_main.nim
@@ -23,7 +23,7 @@ var sConnectEventGroup*: EventGroupHandle_t
 var sIpAddr*: IpAddress
 var sConnectionName*: cstring
 
-proc ipReceivedHandler*(arg: pointer; event_base: esp_event_base_t; event_id: int32;
+proc ipReceivedHandler*(arg: esp_event_base_t; event_base: esp_event_base_t; event_id: int32;
               event_data: pointer) {.cdecl.} =
   var event: ptr ip_event_got_ip_t = cast[ptr ip_event_got_ip_t](event_data)
   logi TAG, "event.ip_info.ip: %s", $(event.ip_info.ip)
@@ -33,7 +33,7 @@ proc ipReceivedHandler*(arg: pointer; event_base: esp_event_base_t; event_id: in
   logw TAG, "got event ip: %s", $sIpAddr
   discard xEventGroupSetBits(sConnectEventGroup, GOT_IPV4_BIT)
 
-proc onWifiDisconnect*(arg: pointer;
+proc onWifiDisconnect*(arg: esp_event_base_t;
                           event_base: esp_event_base_t;
                           event_id: int32;
                           event_data: pointer) {.cdecl.} =


### PR DESCRIPTION
With the pointer type it wouldn't compile on Nim 2.0.2