### PR TITLE
Make the original ESP_IDF_VERSION available, fix event loop legacy and WiFi struct on v5.0+

### DIFF
--- a/nesper.nimble
+++ b/nesper.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.7.3"
+version       = "0.7.4"
 author        = "Jaremy Creechley"
 description   = "Nim wrappers for ESP-IDF (ESP32)"
 license       = "Apache-2.0"

--- a/src/nesper/build_utils/tasks.nim
+++ b/src/nesper/build_utils/tasks.nim
@@ -220,7 +220,8 @@ task esp_compile, "Compile Nim project for esp-idf program":
     echo "...cleaning esp-idf build cache"
     rmDir(nopts.projdir / "build")
 
-  echo "ESP_IDF_VERSION: ", nopts.esp_idf_version
+  var esp_idf_version_formatted = nopts.esp_idf_version[0..2]
+  echo "ESP IDF VERSION: ", esp_idf_version_formatted
   let
     nimargs = @[
       "c",
@@ -229,8 +230,8 @@ task esp_compile, "Compile Nim project for esp-idf program":
       "--compileOnly",
       "--nimcache:" & nopts.cachedir.quoteShell(),
       "-d:NimAppMain",
-      "-d:ESP_IDF_V" & nopts.esp_idf_version.replace(".","_"),
-      "-d:ESP_IDF_VERSION=" & nopts.esp_idf_version,
+      "-d:ESP_IDF_V" & esp_idf_version_formatted.replace(".","_"),
+      "-d:ESP_IDF_VERSION=" & esp_idf_version_formatted,
     ].join(" ") 
     childargs = nopts.child_args.mapIt(it.quoteShell()).join(" ")
     wifidefs = nopts.wifi_args

--- a/src/nesper/build_utils/templates/esp32_templates/networking/CMakeLists.txt
+++ b/src/nesper/build_utils/templates/esp32_templates/networking/CMakeLists.txt
@@ -1,7 +1,13 @@
+set(requires lwip newlib nvs_flash app_update)
+
+string(SUBSTRING "$${IDF_VER}" 1 3 IDF_VER_VAL_STR)
+if("$${IDF_VER_VAL_STR}" VERSION_GREATER_EQUAL "5.0")
+    list(APPEND requires esp_netif)
+endif()
 
 idf_component_register(SRC_DIRS "$NIMBLE_NIMCACHE"
                     INCLUDE_DIRS ""
-                    REQUIRES lwip newlib nvs_flash app_update)
+                    REQUIRES $${requires})
 
 # set(C_COMPILE_OPTIONS "$${C_COMPILE_OPTIONS} -Wno-error=unused-label")
 # list(APPEND C_COMPILE_OPTIONS "-Wno-error=unused-label ")

--- a/src/nesper/esp/esp_event.nim
+++ b/src/nesper/esp/esp_event.nim
@@ -13,9 +13,11 @@
 ##  limitations under the License.
 
 import ../consts
-import esp_event_legacy
 
-export esp_event_legacy
+when ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0):
+  import esp_event_legacy
+
+  export esp_event_legacy
 
 
 ## / Configuration for creating event loops

--- a/src/nesper/esp/mdns.nim
+++ b/src/nesper/esp/mdns.nim
@@ -13,7 +13,8 @@
 
 import ../consts
 import ../net_utils
-import ../esp/esp_event_legacy
+
+import ../esp/esp_event
 
 import ../esp/net/esp_netif
 

--- a/src/nesper/esp/net/esp_eth.nim
+++ b/src/nesper/esp/net/esp_eth.nim
@@ -21,8 +21,6 @@ export esp_eth_com
 export esp_eth_mac
 export esp_eth_phy
 
-# import ../esp_event_legacy
-
 ## *
 ##  @brief Handle of Ethernet driver
 ##

--- a/src/nesper/esp/net/esp_wifi.nim
+++ b/src/nesper/esp/net/esp_wifi.nim
@@ -53,7 +53,7 @@
 
 import ../../consts
 import ../../general
-import ../esp_event_legacy
+import ../esp_event
 import ../../net_utils
 import esp_wifi_types
 
@@ -90,7 +90,9 @@ const
 
 type
   wifi_init_config_t* {.importc: "wifi_init_config_t", header: "esp_wifi.h".} = object
-    event_handler* {.importc: "event_handler".}: system_event_handler_t ## *< WiFi event handler
+    when ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0):
+      event_handler* {.importc: "event_handler".}: system_event_handler_t ## *< WiFi event handler
+
     osi_funcs* {.importc: "osi_funcs".}: ptr wifi_osi_funcs_t ## *< WiFi OS functions
     wpa_crypto_funcs* {.importc: "wpa_crypto_funcs".}: wpa_crypto_funcs_t ## *< WiFi station crypto functions when connect
     static_rx_buf_num* {.importc: "static_rx_buf_num".}: cint ## *< WiFi static RX buffer number
@@ -98,17 +100,35 @@ type
     tx_buf_type* {.importc: "tx_buf_type".}: cint ## *< WiFi TX buffer type
     static_tx_buf_num* {.importc: "static_tx_buf_num".}: cint ## *< WiFi static TX buffer number
     dynamic_tx_buf_num* {.importc: "dynamic_tx_buf_num".}: cint ## *< WiFi dynamic TX buffer number
+
+    when ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0):
+      rx_mgmt_buf_type* {.importc: "rx_mgmt_buf_type".}: cint ## *< WiFi RX MGMT buffer type
+      rx_mgmt_buf_num* {.importc: "rx_mgmt_buf_num".}: cint ## *< WiFi RX MGMT buffer number
+      cache_tx_buf_num* {.importc: "cache_tx_buf_num".}: cint ## *< WiFi TX cache buffer number
+
     csi_enable* {.importc: "csi_enable".}: cint ## *< WiFi channel state information enable flag
     ampdu_rx_enable* {.importc: "ampdu_rx_enable".}: cint ## *< WiFi AMPDU RX feature enable flag
     ampdu_tx_enable* {.importc: "ampdu_tx_enable".}: cint ## *< WiFi AMPDU TX feature enable flag
     nvs_enable* {.importc: "nvs_enable".}: cint ## *< WiFi NVS flash enable flag
     nano_enable* {.importc: "nano_enable".}: cint ## *< Nano option for printf/scan family enable flag
-    tx_ba_win* {.importc: "tx_ba_win".}: cint ## *< WiFi Block Ack TX window size
+
+    when ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0):
+      tx_ba_win* {.importc: "tx_ba_win".}: cint ## *< WiFi Block Ack TX window size
+
     rx_ba_win* {.importc: "rx_ba_win".}: cint ## *< WiFi Block Ack RX window size
     wifi_task_core_id* {.importc: "wifi_task_core_id".}: cint ## *< WiFi Task Core ID
     beacon_max_len* {.importc: "beacon_max_len".}: cint ## *< WiFi softAP maximum length of the beacon
     mgmt_sbuf_num* {.importc: "mgmt_sbuf_num".}: cint ## *< WiFi management short buffer number, the minimum value is 6, the maximum value is 32
     feature_caps* {.importc: "feature_caps".}: uint64 ## *< Enables additional WiFi features and capabilities
+
+    when ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0):
+      sta_disconnected_pm* {.importc: "sta_disconnected_pm".}: bool ## *< WiFi Power Management for station at disconnected status
+      espnow_max_encrypt_num* {.importc: "espnow_max_encrypt_num".}: cint ## *< Maximum encrypt number of peers supported by espnow
+
+    when ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0):
+      tx_hetb_queue_num* {.importc: "tx_hetb_queue_num".}: cint ## *< WiFi TX HE TB QUEUE number for STA HE TB PPDU transmission */
+      dump_hesigb_enable* {.importc: "dump_hesigb_enable".}: bool ## *< enable dump sigb field */
+
     magic* {.importc: "magic".}: cint ## *< WiFi init magic number, it should be the last field
 
 


### PR DESCRIPTION
I tried to compile the default example from README on IDF v5.0+ but it didn't work so this should fix it.

I tested it on IDF v5.0 and v5.2 (with e.g. `nimble esp_build --esp-idf-version=V5.2`) and it worked.

I also renamed ESP_IDF_VERSION to ESP_IDF_VERSION_STR so I can implement real ESP_IDF_VERSION from IDF, hope it isn't a problem.